### PR TITLE
refactor: improve layout and accessibility in withdrawal steps

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -25,7 +25,7 @@ const App = ({ children }: { children: React.ReactNode }) => {
           className={classNames(
             "w-full flex relative lg:border-t-0 lg:rounded-t-none lg:bg-transparent lg:overflow-visible mt-7 p-6 lg:p-0 border-t border-primary-150 rounded-t-[32px] bg-white overflow-y-scroll",
             {
-              "items-center justify-center": !showNavigation,
+              "lg:items-center lg:justify-center": !showNavigation,
               "lg:gap-[100px] lg:px-5 lg:pt-0": showNavigation,
             }
           )}

--- a/views/terminal/agent-log.tsx
+++ b/views/terminal/agent-log.tsx
@@ -10,7 +10,7 @@ const Log = ({ date, message, type, initiator, loading }: Log) => {
   const formattedDate = moment(date).format("h:mm a");
 
   return (
-    <div className="self-stretch flex items-center justify-between gap-10 text-[15px] leading-[19.8px]">
+    <div className="self-stretch flex items-center justify-between gap-8 text-[15px] leading-[19.8px]">
       <div className="flex items-center gap-1">
         <span className="text-primary-600">{">>>"}</span>
 
@@ -42,7 +42,9 @@ const Log = ({ date, message, type, initiator, loading }: Log) => {
         )}
       </div>
 
-      <span className="text-primary-100">{formattedDate}</span>
+      <span className="text-primary-100 whitespace-nowrap">
+        {formattedDate}
+      </span>
     </div>
   );
 };

--- a/views/wallet/withdraw/step1.tsx
+++ b/views/wallet/withdraw/step1.tsx
@@ -2,14 +2,15 @@ import Image from "next/image";
 import { motion } from "framer-motion";
 import { WalletIconInactive } from "@/public/icons";
 import { LWButton } from "@/components";
+import { step } from "viem/chains";
 
-const Step1 = ({ setStep, setAddress, address }: WithdrawStepProps) => {
+const Step1 = ({ step, setStep, setAddress, address }: WithdrawStepProps) => {
   const handleNext = () => {
     setStep?.(1);
   };
 
   return (
-    <div className="flex flex-col items-stretch justify-between h-full">
+    <div className="flex flex-col items-stretch justify-between h-80 lg:h-full gap-">
       <div className="self-stretch flex flex-col items-stretch gap-2">
         <div className="self-stretch px-4 py-2.5 flex items-center justify-center gap-2 rounded-[26px] border border-primary-550 shadow-withdrawAddressInput h-[60px]">
           <input
@@ -19,6 +20,7 @@ const Step1 = ({ setStep, setAddress, address }: WithdrawStepProps) => {
             className="w-full text-[16px] leading-[19.84px] text-primary-2400 bg-transparent outline-none"
             onChange={(e) => setAddress?.(e.target.value)}
             value={address}
+            disabled={step! > 0}
           />
 
           <div className="min-w-fit">

--- a/views/wallet/withdraw/step2.tsx
+++ b/views/wallet/withdraw/step2.tsx
@@ -18,6 +18,7 @@ const Step2 = ({
   const { truncatedText } = useTruncateText(address, 8, 8);
   const [inputWidth, setInputWidth] = useState(50);
   const spanRef = useRef<HTMLSpanElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const { isEthValid, isSolValid } = useAddressValidator(address || "", 1);
   const { sendTransaction } = useTransaction(onClose);
 
@@ -39,12 +40,19 @@ const Step2 = ({
 
   useEffect(() => {
     if (spanRef.current) {
-      setInputWidth(spanRef.current.offsetWidth + 10); // +10px for padding
+      setInputWidth(spanRef.current.offsetWidth + 10);
     }
   }, [amount]);
 
+  useEffect(() => {
+    containerRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  }, []);
+
   return (
-    <div className="self-stretch flex flex-col gap-24">
+    <div ref={containerRef} className="self-stretch flex flex-col gap-24">
       <div className="flex flex-col gap-3">
         <div className="self-stretch px-4 py-2.5 flex items-center justify-center gap-2 border-b border-b-primary-550 shadow-withdrawAddressInput h-[60px]">
           <p className="w-full text-[16px] leading-[19.84px] text-primary-950 font-medium">

--- a/views/wallet/withdraw/types.ts
+++ b/views/wallet/withdraw/types.ts
@@ -1,6 +1,7 @@
 interface WithdrawStepProps {
   address?: string;
   amount?: string;
+  step?: number;
   setStep?: (step: number) => void;
   setAmount?: (value: string) => void;
   setAddress?: (address: string) => void;


### PR DESCRIPTION
In this PR, the bug that causes the content of the page to be cut off on mobile screens was fixed.
Correspondingly, accessibility of the withdrawal steps was enhanced to improve UX.